### PR TITLE
bump to beta

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,15 +34,16 @@ def find_install_requires():
 
 setup(
     name="socorrolib",
-    version="0.0.1",
-    description="the common library of the socorro crash reporter",
-    license="MPL-2",
+    version="0.1.0",
     author="mozilla socorro team and friends",
+    url="https://github.com/mozilla/socorrolib",
+    description="the common library of the socorro crash reporter",
+    long_description=read("README.md"),
+    license="MPL-2",
     packages=find_packages(),
     install_requires=find_install_requires(),
-    long_description=read("README.md"),
     classifiers=[
-        "Development Status :: 1 - Planning",
+        "Development Status :: 4 - Beta",
         "Environment :: Console",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Programming Language :: Python",


### PR DESCRIPTION
Bumping versions to 0.1.0 and beta status for pypi. This will also serve as a test of the travis deploy to pypi features after it is merged and a tag is made.
