### PR TITLE
bring up to date with socorro 1c485ce3e6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The common library of the socorro crash reporter system.
 
 Factoring out the common library is the first step to breaking up the mozilla/socorro monorepo, which contains multiple services as a historic quirk of Mozilla's development and deployment process.
 
-Currently socorrolib is pinned to socorro revision: 8e9b1ca1c33f385d7c12fc844c7aa60075b33da4
+Currently socorrolib is pinned to socorro revision:
+1c485ce3e6e6b2839834ad8a9f184e407dc8c825
 
 Eventually this relationship will invert and socorro should use standard import tools to pin a version of socorrolib.
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def find_install_requires():
 
 setup(
     name="socorrolib",
-    version="0.1.2",
+    version="0.2.0",
     author="mozilla socorro team and friends",
     url="https://github.com/mozilla/socorrolib",
     description="the common library of the socorro crash reporter",

--- a/socorrolib/lib/__init__.py
+++ b/socorrolib/lib/__init__.py
@@ -1,0 +1,68 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""common library code for socorro modules"""
+
+
+class InsertionError(Exception):
+    """When an insertion into a storage system failed. """
+    pass
+
+
+class DatabaseError(Exception):
+    """When querying a storage system failed. """
+    pass
+
+
+class MissingArgumentError(Exception):
+    """When a mandatory argument is missing or empty. """
+    def __init__(self, arg):
+        self.arg = arg
+
+    def __str__(self):
+        try:
+            msg = "Mandatory parameter(s) '%s' is missing or empty." \
+                % self.arg
+            return msg
+        except Exception:
+            pass
+
+
+class BadArgumentError(Exception):
+    """When a mandatory argument has a bad value. """
+    def __init__(self, param, received=None, expected=None, msg=None):
+        self.param = param
+        self.msg = msg
+        self.received = received
+        self.expected = expected
+
+    def __str__(self):
+        if self.msg is not None:
+            return self.msg
+
+        try:
+            msg = "Bad value for parameter(s) '%s'" % self.param
+            if self.received is not None:
+                msg = msg + " got '%s'" % self.received
+            if self.expected is not None:
+                msg = msg + " expected '%s'" % self.expected
+            return msg
+        except Exception:
+            pass
+
+
+class ResourceNotFound(Exception):
+    """When a resource could not be found in a storage system. """
+    pass
+
+
+class ResourceUnavailable(Exception):
+    """When a resource could not be found in a storage system because it is
+    not ready yet (but could be accessible later). """
+    pass
+
+
+class ServiceUnavailable(Exception):
+    """When a service is requested but cannot be found"""
+    pass

--- a/socorrolib/lib/external_common.py
+++ b/socorrolib/lib/external_common.py
@@ -7,21 +7,41 @@ Common functions for external modules.
 """
 
 import json
+import datetime
 
-from datetime import datetime, timedelta, date
+from socorrolib.lib import BadArgumentError
 from socorrolib.lib.util import DotDict
+import socorrolib.lib.datetimeutil as dtutil
 
-import  socorrolib.lib.datetimeutil as dtutil
 
-
-def parse_arguments(filters, arguments):
+def parse_arguments(filters, arguments, modern=False):
     """
     Return a dict of parameters.
-
     Take a list of filters and for each try to get the corresponding
     value in arguments or a default value. Then check that value's type.
-
-    Example:
+    The @modern parameter indicates how the arguments should be
+    interpreted. The old way is that you always specify a list and in
+    the list you write the names of types as strings. I.e. instad of
+    `str` you write `'str'`.
+    The modern way allows you to specify arguments by real Python types
+    and entering it as a list means you accept and expect it to be a list.
+    For example, using the modern way:
+        filters = [
+            ("param1", "default", [str]),
+            ("param2", None, int),
+            ("param3", ["list", "of", 4, "values"], [str])
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345
+        }
+        =>
+        {
+            "param1": ["value1"],
+            "param2": 0,
+            "param3": ["list", "of", "4", "values"]
+        }
+    And an example for the old way:
         filters = [
             ("param1", "default", ["list", "str"]),
             ("param2", None, "int"),
@@ -37,6 +57,8 @@ def parse_arguments(filters, arguments):
             "param2": 0,
             "param3": ["list", "of", "4", "values"]
         }
+    The reason for having the modern and the non-modern way is
+    transition of legacy code. One day it will all be the modern way.
     """
     params = DotDict()
 
@@ -49,26 +71,37 @@ def parse_arguments(filters, arguments):
         else:
             param = arguments.get(i[0], i[1])
 
+        # proceed and do the type checking
         if count >= 3:
             types = i[2]
-            if not isinstance(types, list):
-                types = [types]
 
-            for t in reversed(types):
-                if t == "list" and not isinstance(param, list):
-                    if param is None or param == '':
-                        param = []
-                    else:
+            if modern:
+                if isinstance(types, list) and param is not None:
+                    assert len(types) == 1
+                    if not isinstance(param, list):
                         param = [param]
-                elif t == "list" and isinstance(param, list):
-                    continue
-                elif isinstance(param, list) and "list" not in types:
-                    param = " ".join(param)
-                    param = check_type(param, t)
-                elif isinstance(param, list):
-                    param = [check_type(x, t) for x in param]
+                    param = [check_type(x, types[0]) for x in param]
                 else:
-                    param = check_type(param, t)
+                    param = check_type(param, types)
+            else:
+                if not isinstance(types, list):
+                    types = [types]
+
+                for t in reversed(types):
+                    if t == "list" and not isinstance(param, list):
+                        if param is None or param == '':
+                            param = []
+                        else:
+                            param = [param]
+                    elif t == "list" and isinstance(param, list):
+                        continue
+                    elif isinstance(param, list) and "list" not in types:
+                        param = " ".join(param)
+                        param = check_type(param, t)
+                    elif isinstance(param, list):
+                        param = [check_type(x, t) for x in param]
+                    else:
+                        param = check_type(param, t)
 
         params[i[0]] = param
     return params
@@ -77,7 +110,6 @@ def parse_arguments(filters, arguments):
 def check_type(param, datatype):
     """
     Make sure that param is of type datatype and return it.
-
     If param is None, return it.
     If param is an instance of datatype, return it.
     If param is not an instance of datatype and is not None, cast it as
@@ -86,34 +118,60 @@ def check_type(param, datatype):
     if param is None:
         return param
 
-    if datatype == "str" and not isinstance(param, basestring):
+    if getattr(datatype, 'clean', None) and callable(datatype.clean):
+        try:
+            return datatype.clean(param)
+        except ValueError:
+            raise BadArgumentError(param)
+
+    elif isinstance(datatype, str):
+        # You've given it something like `'bool'` as a string.
+        # This is the legacy way of doing it.
+        datatype = {
+            'str': str,
+            'bool': bool,
+            'float': float,
+            'date': datetime.date,
+            'datetime': datetime.datetime,
+            'timedelta': datetime.timedelta,
+            'json': 'json',  # exception
+            'int': int,
+        }[datatype]
+
+    if datatype is str and not isinstance(param, basestring):
         try:
             param = str(param)
         except ValueError:
             param = str()
 
-    elif datatype == "int" and not isinstance(param, int):
+    elif datatype is int and not isinstance(param, int):
         try:
             param = int(param)
         except ValueError:
             param = int()
 
-    elif datatype == "bool" and not isinstance(param, bool):
+    elif datatype is bool and not isinstance(param, bool):
         param = str(param).lower() in ("true", "t", "1", "y", "yes")
 
-    elif datatype == "datetime" and not isinstance(param, datetime):
+    elif (
+        datatype is datetime.datetime and
+        not isinstance(param, datetime.datetime)
+    ):
         try:
             param = dtutil.string_to_datetime(param)
         except ValueError:
             param = None
 
-    elif datatype == "date" and not isinstance(param, date):
+    elif datatype is datetime.date and not isinstance(param, datetime.date):
         try:
             param = dtutil.string_to_datetime(param).date()
         except ValueError:
             param = None
 
-    elif datatype == "timedelta" and not isinstance(param, timedelta):
+    elif (
+        datatype is datetime.timedelta and
+        not isinstance(param, datetime.timedelta)
+    ):
         try:
             param = dtutil.strHoursToTimeDelta(param)
         except ValueError:

--- a/socorrolib/unittest/lib/test_external_common.py
+++ b/socorrolib/unittest/lib/test_external_common.py
@@ -4,9 +4,10 @@
 
 import datetime
 
-from nose.tools import eq_, ok_
+import isodate
+from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import external_common, util
+from socorrolib.lib import BadArgumentError, external_common, util
 from socorrolib.unittest.testbase import TestCase
 
 
@@ -107,7 +108,7 @@ class TestExternalCommon(TestCase):
         eq_(res.day, 1)
 
     #--------------------------------------------------------------------------
-    def test_parse_arguments(self):
+    def test_parse_arguments_old_way(self):
         """Test external_common.parse_arguments(). """
         filters = [
             ("param1", "default", ["list", "str"]),
@@ -123,6 +124,101 @@ class TestExternalCommon(TestCase):
         params_exp.param2 = None
         params_exp.param3 = ["list", "of", "4", "values"]
 
-        params = external_common.parse_arguments(filters, arguments)
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=False,
+        )
 
         eq_(params, params_exp)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments(self):
+        """Test external_common.parse_arguments(). """
+        filters = [
+            ("param1", "default", [str]),
+            ("param2", None, int),
+            ("param3", ["some", "default", "list"], [str]),
+            ("param4", ["list", "of", 4, "values"], [str]),
+            ("param5", None, bool),
+            ("param6", None, datetime.date),
+            ("param7", None, datetime.date),
+            ("param8", None, datetime.datetime),
+            ("param9", None, [str]),
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345,
+            "param5": "true",
+            "param7": datetime.date(2016, 2, 9).isoformat(),
+            "param8": datetime.datetime(2016, 2, 9).isoformat(),
+            # note the 'param9' is deliberately not specified.
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = ["value1"]
+        params_exp.param2 = None
+        params_exp.param3 = ['some', 'default', 'list']
+        params_exp.param4 = ["list", "of", "4", "values"]
+        params_exp.param5 = True
+        params_exp.param6 = None
+        params_exp.param7 = datetime.date(2016, 2, 9)
+        params_exp.param8 = datetime.datetime(2016, 2, 9).replace(
+            tzinfo=isodate.UTC
+        )
+        params_exp.param9 = None
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=True
+        )
+        for key in params:
+            eq_(params[key], params_exp[key], '{}: {!r} != {!r}'.format(
+                key,
+                params[key],
+                params_exp[key]
+            ))
+        eq_(params, params_exp)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments_with_class_validators(self):
+
+        class NumberConverter(object):
+
+            def clean(self, value):
+                conv = {'one': 1, 'two': 2, 'three': 3}
+                try:
+                    return conv[value]
+                except KeyError:
+                    raise ValueError('No idea?!')
+
+        # Define a set of filters with some types being non-trivial types
+        # but instead a custom validator.
+
+        filters = [
+            ("param1", 0, NumberConverter()),
+        ]
+        arguments = {
+            "param1": "one",
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = 1
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=True
+        )
+        eq_(params, params_exp)
+
+        # note that a ValueError becomes a BadArgumentError
+        arguments = {
+            "param1": "will cause a ValueError in NumberConverter.clean",
+        }
+        assert_raises(
+            BadArgumentError,
+            external_common.parse_arguments,
+            filters,
+            arguments,
+            modern=True
+        )


### PR DESCRIPTION
bring socorrolib up to date with socorro 1c485ce3e6, which includes porting a bunch of error types from /externals/ into the common lib. these errors are not especially attached to external, and re-used by the external_common lib. unlike the search utils, external_common represents an actual common library. looking ahead, the classes that rely on it will likely end up here in the common library, as will the errors. we can change it later if another path becomes clear.
