### PR TITLE
handle testing when not installed

### DIFF
--- a/socorrolib/__init__.py
+++ b/socorrolib/__init__.py
@@ -1,3 +1,6 @@
 from pkg_resources import get_distribution
 
-__version__ = get_distribution('socorrolib').version
+try:
+    __version__ = get_distribution('socorrolib').version
+except DistributionNotFound:
+    __version__ = 'Please install this project with setup.py'


### PR DESCRIPTION
Packaging is deceptively, incredibly complicated in Python and the language has a convention to publish version numbers as an attribute of a module and a convention to avoid duplication. It offers no standard means of achieving this, though, and we're stuck figuring it out.

Previously we relied on the package info utilities in order to leave the version in the setup.py file, instead of indirectly reading it from a file in the package somehow. This is a problem when the package is not installed and you try to run tests or use it directly from the filesystem containing the source code.

This patch resolves that case by catching the DistributionNotFound error and setting the **version** string to a prompt instructing the user to run setup.py.
