### PR TITLE
use socorro's path to build file path to stored proc, #23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
 try:
     # pylint: disable=W0611,C0411
-    import multiprocessing
+    import multiprocessing  # noqa
 except ImportError:
     pass
 
@@ -24,6 +24,7 @@ def read(fname):
     with codecs.open(fpath, 'r', 'utf8') as fhandle:
         return fhandle.read().strip()
 
+
 def find_install_requires():
     """
     utility function to build a list of requirements from requirements.txt
@@ -34,7 +35,7 @@ def find_install_requires():
 
 setup(
     name="socorrolib",
-    version="0.2.3",
+    version="0.2.4",
     author="mozilla socorro team and friends",
     url="https://github.com/mozilla/socorrolib",
     description="the common library of the socorro crash reporter",

--- a/socorrolib/lib/migrations.py
+++ b/socorrolib/lib/migrations.py
@@ -12,6 +12,8 @@ defined in SQLAlchemy yet.
 import os
 import warnings
 
+import socorro
+
 
 def get_local_filepath(filename):
     """
@@ -21,14 +23,13 @@ def get_local_filepath(filename):
         $SOCORRO_PATH/socorrolib/external/postgresql/raw_sql/procs/
     """
     procs_dir = os.path.normpath(os.path.join(
-        __file__,
-        '../../',
+        socorro.__path__[0],
         'external/postgresql/raw_sql/procs'
     ))
     return os.path.join(procs_dir, filename)
 
 
-def load_stored_proc(op, filelist):
+def load_stored_proc(op, filelist, must_exist=False):
     """
     Takes the alembic op object as arguments and a list of files as arguments
     Load and run CREATE OR REPLACE function commands from files
@@ -39,7 +40,7 @@ def load_stored_proc(op, filelist):
         # an exception to be thrown. Some of the rollback scripts
         # would otherwise throw unhelpful exceptions when a SQL
         # file is removed from the repo.
-        if not os.path.isfile(sqlfile):
+        if not must_exist and not os.path.isfile(sqlfile):
             warnings.warn(
                 "Did not find %r. Continuing migration." % sqlfile,
                 UserWarning,


### PR DESCRIPTION
The cool thing is that I was able to test this quite confidently. 
I fiddled the `alembic_version` table in my local socorro PG database. Then I ran `PYTHONPATH=. alembic -c config/alembic.ini upgrade head` and it ran this new code. 
At first I put in an assert statement (and some printing) and if the file doesn't exist it now raises an error. 

However, I'm being conservative here. I made the `must_exist` false by default so that it doesn't break old migrations we have to run in travis. 

After this lands, 
socorro needs to point to version 0.2.4 and I will update update [the old script](https://github.com/mozilla/socorro/blob/master/alembic/versions/495e6c766315_reload_sunset_date_function.py) to have `must_exist=True`
I also need to fake stage's db to point to one version back. 